### PR TITLE
Block the beam branch with specific beam index

### DIFF
--- a/PyOpticL/laser.py
+++ b/PyOpticL/laser.py
@@ -130,6 +130,7 @@ class beam_path:
         obj.addProperty('Part::PropertyPartShape', 'DrillPart')
         obj.addProperty('App::PropertyLength', 'Width').Width = width
         obj.addProperty('App::PropertyLength', 'DrillWidth').DrillWidth = drill_width
+        obj.addProperty('App::PropertyIntegerList', 'BlockedBeams').BlockedBeams = []
         self.components = [[]]
 
     def __getstate__(self):
@@ -177,6 +178,9 @@ class beam_path:
     # compute full beam path given start point and angle
     def calculate_beam_path(self, selfobj, x1, y1, a1, beam_index=1):
         if beam_index > max_beam_index:
+            return
+
+        if hasattr(selfobj, "BlockedBeams") and beam_index in selfobj.BlockedBeams:
             return
         
         count = 0 # number of interactions per beam
@@ -323,17 +327,30 @@ class beam_path:
             
             # compute next beam and handle recursion for beam splits
             if af_arr[0] != None and af_arr[1] != None:
-                self.calculate_beam_path(selfobj, xf, yf, af_arr[0], (beam_index<<1))
-                beam_index = (beam_index<<1)+1
+                child0 = (beam_index << 1)
+                child1 = (beam_index << 1) + 1
+
+                # trace first child normally
+                self.calculate_beam_path(selfobj, xf, yf, af_arr[0], child0)
+
+                # if second child is blocked, stop here
+                if hasattr(selfobj, "BlockedBeams") and child1 in selfobj.BlockedBeams:
+                    return
+
+                beam_index = child1
                 inline_comps = []
                 for obj in selfobj.PathObjects:
                     if obj.BeamIndex == beam_index:
                         inline_comps.append(obj)
                 comp_index = 0
+
             if af_arr[1] != None:
                 x1, y1, a1 = xf, yf, af_arr[1]
                 count += 1
             elif af_arr[0] != None:
+                # if transmitted-only child is blocked, stop
+                if hasattr(selfobj, "BlockedBeams") and beam_index in selfobj.BlockedBeams:
+                    return
                 x1, y1, a1 = xf, yf, af_arr[0]
                 count += 1
             else:


### PR DESCRIPTION
In the original package there is no way of controlling the beam propagation 

```python

from PyOpticL import layout, optomech
import FreeCAD as App

base_dx = 200
base_dy = 200
base_dz = 100
gap = 3
inch = layout.inch
spacing = 25

def demo_layout(x=0, y=0, angle=0):
    bp = layout.baseplate(
        base_dx, base_dy, base_dz,
        x=x, y=y, angle=angle,
        gap=gap, optics_dz = 50,
        name="demo",
        label="demo",
    )
    bp.metric = True
    layout.set_max_beam_index(1024)  

    beam = bp.add_beam_path(x=100, y=base_dy, angle=layout.cardinal['down'], color=(1.0, 0.0, 0.0))

    bp.place_element_along_beam("HWP1", optomech.waveplate, beam,
                                       beam_index=0b1, distance=50, angle=layout.cardinal['down'],
                                       mount_type=optomech.rotation_stage_rsp05)

    bp.place_element_along_beam("PBS1", optomech.cube_splitter, beam,
                                       beam_index=0b1, distance=50, angle=layout.cardinal['left'],
                                       mount_type=optomech.skate_mount)
                                                                                                         

    return bp

if __name__ == "__main__":
    demo_layout()
    layout.redraw()
```

This produces a beam that is split by the cube.

<img width="628" height="463" alt="demo_no_block" src="https://github.com/user-attachments/assets/96776629-10e1-4c36-820b-8822d6b8df04" />

Now with this patch you can turn off a specific branch. Add this after beam instantiation

```python
beam.BlockedBeams = [0b10]
```

You can get pure reflection.
<img width="644" height="498" alt="demo_block" src="https://github.com/user-attachments/assets/6dc9cbe0-933e-4fd3-84e5-5ba40c1bc5fa" />