### PR TITLE
pad_to_grid convenience option to align placed component with the grid

### DIFF
--- a/PyOpticL/beam_path.py
+++ b/PyOpticL/beam_path.py
@@ -209,6 +209,7 @@ class BeamSegment(Layout):
         self,
         type: str,
         value: float,
+        pad_to_grid: bool,
     ) -> np.ndarray[float]:
         """
         Get the position of the beam at a specified distance or coordinate
@@ -244,6 +245,15 @@ class BeamSegment(Layout):
         # calculate position based on specified constraint
         if type == "distance":
             output = position + value * direction
+            if pad_to_grid:
+                axis = np.argmax(np.abs(direction))   # pick the cardinal direction most closely aligned to the beam
+                spacing = dim(1, "grid")
+
+                target = (output[axis]// spacing) * spacing 
+                if direction[axis] > 0:
+                    target += spacing
+                t = (target - position[axis]) / direction[axis]
+                output = position + t * direction
         if type == "xPosition":
             if isclose(direction[0], 0):
                 raise RuntimeError(
@@ -591,6 +601,7 @@ class BeamPath(Layout):
         after_object: Layout = None,
         offset: tuple[dim] = (0, 0),
         interface_index: int = 0,
+        pad_to_grid: bool = False
     ) -> Layout:
         """
         Add a child layout to the beam path and assign beam index
@@ -606,7 +617,7 @@ class BeamPath(Layout):
             after_object (Layout): Only apply contraint after beam interacts with this object
             offset (tuple): (y, z) offset from the center of the interface
             interface_index (int): Index of the interface on the child object to interact with
-
+            pad_to_grid (bool): align position with grid
         Returns:
             child (Layout): The added child layout
         """
@@ -629,10 +640,13 @@ class BeamPath(Layout):
         child_obj = child.get_object()
         child.make_property("ConstraintValue", "App::PropertyLength")
         child.make_property("ConstraintType", "App::PropertyEnumeration")
+        child.make_property("PadToGrid", "App::PropertyBool")
+
         child_obj.ConstraintType = ["distance", "xPosition", "yPosition", "zPosition"]
         if distance is not None:
             child_obj.ConstraintType = "distance"
             child_obj.ConstraintValue = distance
+            child_obj.PadToGrid = pad_to_grid
         if x_position is not None:
             child_obj.ConstraintType = "xPosition"
             child_obj.ConstraintValue = x_position
@@ -825,7 +839,7 @@ class BeamPath(Layout):
             # get position from provided constraint
             try:
                 next_position = input_beam.get_constraint_position(
-                    next_object.ConstraintType, next_object.ConstraintValue.Value
+                    next_object.ConstraintType, next_object.ConstraintValue.Value, next_object.PadToGrid
                 )
             except RuntimeError as e:
                 raise RuntimeError(
@@ -940,7 +954,7 @@ class BeamPath(Layout):
 
             # get object placement
             intercept = input_beam.get_constraint_position(
-                type="distance", value=next_distance
+                type="distance", value=next_distance, pad_to_grid=next_object.PadToGrid
             )
             next_object.Proxy.compute_placement()  # update placement
             object_rotation = next_object.Placement.Rotation


### PR DESCRIPTION
An additional constraint option for beampath.add() to make it easier to comply with the convention of aligning any outputs to the grid. Example usage: 
```
beam_path.add(Component(label="Lens", definition=lens),
                          beam_index=0b1,
                          distance=dim(10, "mm"),
                          rotation=(0, 0, 0),
)
beam_path.add(Component(label="Waveplate", definition=waveplate),
                          beam_index=0b1,
                          distance=dim(10, "mm"),
                          rotation=(0, 0, 0),
)
beam_path.add(Component(label="PBS", definition=pbs),
                          beam_index=0b1,
                          distance=dim(10, "mm"),
                          rotation=(0, 0, 0),
#########################
                          pad_to_grid = True, #Ensures reflected beam is aligned with grid
#########################
)
```

Includes squashed commits by @evazheng2006 