### PR TITLE
Rendering modes STEP and None

### DIFF
--- a/PyOpticL/layout.py
+++ b/PyOpticL/layout.py
@@ -4,8 +4,9 @@ from collections import namedtuple
 
 import FreeCAD as App
 import Part
+import Mesh
 
-from PyOpticL.settings import get_hidden_object_groups
+from PyOpticL.settings import get_hidden_object_groups, get_render_mode
 from PyOpticL.utils import collect_children
 
 Subcomponent = namedtuple("Subcomponent", ["component", "position", "rotation"])
@@ -211,7 +212,11 @@ class Component(Layout):
                     setattr(self, attr, getattr(definition, attr))
 
             if hasattr(definition, "mesh"):
-                object_type = "Mesh"
+                 match get_render_mode():
+                     case "STL":
+                         object_type = "Mesh"
+                     case "STEP":
+                         object_type = "Part"
 
             # wrap interfaces to set parent
             if hasattr(definition, "interfaces"):
@@ -249,12 +254,14 @@ class Component(Layout):
         """Calculate and set the shape of the object"""
 
         obj = self.get_object()
-        if self.object_group in get_hidden_object_groups():
+        if self.object_group in get_hidden_object_groups() or (hasattr(self, "mesh") and self.mesh is None) or get_render_mode() == "NONE":
             pass
-
         # update object shape
-        elif self.object_type == "Part" and hasattr(self, "shape"):
-            shape = self.shape()
+        elif self.object_type == "Part" and (hasattr(self, "shape") or hasattr(self, "mesh")):
+            if hasattr(self, "mesh"):
+                shape = self.mesh
+            else:
+                shape = self.shape()
             if isinstance(shape, list):  # if multiple shapes are returned, fuse
                 combined = shape[0]
                 for part in shape[1:]:
@@ -289,32 +296,33 @@ class Component(Layout):
                         drill_shape.Placement = (
                             obj.Placement.inverse() * drill_obj.Placement
                         )
+                        if hasattr(self, "shape"):
+                            # make sure drill intersects shape
+                            common = shape.common(drill_shape)
+                            if common.Volume < 1e-6 or drill_shape.Volume < 1e-6:
+                                continue
 
-                        # make sure drill intersects shape
-                        common = shape.common(drill_shape)
-                        if common.Volume < 1e-6 or drill_shape.Volume < 1e-6:
-                            continue
+                            rotation = drill_shape.Placement.Rotation.inverted()
+                            z_direction = rotation.multVec(App.Vector(0, 0, 1))
 
-                        rotation = drill_shape.Placement.Rotation.inverted()
-                        z_direction = rotation.multVec(App.Vector(0, 0, 1))
+                            # find and extrude +z-facing faces from drill_obj
+                            for face in drill_shape.Faces:
+                                normal = face.normalAt(0, 0)
+                                intersection = face.common(shape)
+                                if (
+                                    isinstance(face.Surface, Part.Plane)
+                                    and normal.getAngle(z_direction) < 1e-6
+                                    and intersection.Area > 1e-6
+                                ):
+                                    max_dimension = shape.BoundBox.DiagonalLength
+                                    extrusion = face.extrude(max_dimension * z_direction)
+                                    drill_shape = drill_shape.fuse(extrusion)
 
-                        # find and extrude +z-facing faces from drill_obj
-                        for face in drill_shape.Faces:
-                            normal = face.normalAt(0, 0)
-                            intersection = face.common(shape)
-                            if (
-                                isinstance(face.Surface, Part.Plane)
-                                and normal.getAngle(z_direction) < 1e-6
-                                and intersection.Area > 1e-6
-                            ):
-                                max_dimension = shape.BoundBox.DiagonalLength
-                                extrusion = face.extrude(max_dimension * z_direction)
-                                drill_shape = drill_shape.fuse(extrusion)
-
-                        shape = shape.cut(drill_shape)
+                            shape = shape.cut(drill_shape)
 
             # apply placement and set final shape
-            shape = shape.removeSplitter()
+            if hasattr(self, "shape"):
+                shape = shape.removeSplitter()
             shape.Placement = obj.Placement
             obj.Shape = shape
 

--- a/PyOpticL/settings.py
+++ b/PyOpticL/settings.py
@@ -3,6 +3,7 @@ minimum_thread_engagement = 8
 default_extra_drill_depth = 10
 hidden_object_groups = ["hardware"]
 enable_beam_transparency = False
+render_mode = "STL"
 
 
 def set_measurement_system(system: str):
@@ -121,3 +122,29 @@ def get_enable_beam_transparency():
     """
 
     return enable_beam_transparency
+
+
+def set_render_mode(mode: str):
+    """
+    Set the rendering mode preference.
+
+    Args:
+        mode (str): The rendering mode to use
+    """
+
+    global render_mode
+    if mode.upper() in ["STL", "STEP", "NONE"]:
+        render_mode = mode.upper()
+    else:
+        raise ValueError("Render mode {mode} not defined")
+
+
+def get_render_mode():
+    """
+    Get the current rendering mode.
+
+    Returns:
+        mode: The current rendering mode
+    """
+
+    return render_mode

--- a/PyOpticL/utils.py
+++ b/PyOpticL/utils.py
@@ -10,7 +10,7 @@ import MeshPart
 import numpy as np
 import Part
 
-from PyOpticL.settings import get_measurement_system, get_minimum_thread_engagement
+from PyOpticL.settings import get_measurement_system, get_minimum_thread_engagement, get_render_mode
 
 models_dir = Path(__file__).parent.absolute() / "models"
 
@@ -586,16 +586,16 @@ def default_bolt_length(
 def import_model(
     name: str,
     directory: Path | str = models_dir,
-) -> Mesh.Mesh:
+) -> Mesh.Mesh | Part.Shape:
     """
-    Import a mesh model from a PyOpticL specific models directory
+    Import a model from a PyOpticL specific models directory
 
     Args:
         name (str): Name of the model to import
         directory (Path | str): Path to the models directory (defaults to internal models directory)
 
     Returns:
-        Mesh.Mesh: The imported mesh object
+        model: The imported mesh or shape object depending on the render_mode setting
     """
 
     directory = Path(directory)
@@ -605,7 +605,7 @@ def import_model(
         directory = base_path / directory
 
     model_path = directory / name
-
+    model = None
     try:
         # validate files
         if not directory.is_dir():
@@ -615,25 +615,30 @@ def import_model(
         elif not (model_path / (f"{name}.json")).is_file():
             raise FileNotFoundError(f"Model info file not found")
 
-        if not (model_path / (f"{name}.stl")).is_file():
+        if not (model_path / (f"{name}.stl")).is_file() or get_render_mode() == "STEP":
             if not (model_path / (f"{name}.step")).is_file():
-                raise FileNotFoundError(f"Model STEP file not found")
+                    raise FileNotFoundError(f"Model STEP file not found")
 
             shape = Part.read(str(model_path / (f"{name}.step")))
+            if get_render_mode() == "STL":
+                mesh = MeshPart.meshFromShape(
+                    Shape=shape, LinearDeflection=0.1, AngularDeflection=0.5
+                )
+                mesh.write(str(model_path / (f"{name}.stl")))
+            if get_render_mode() == "STEP":
+                model = shape
 
-            mesh = MeshPart.meshFromShape(
-                Shape=shape, LinearDeflection=0.1, AngularDeflection=0.5
-            )
-            mesh.write(str(model_path / (f"{name}.stl")))
-
-        # read mesh from file
-        mesh = Mesh.read(str(model_path / (f"{name}.stl")))
+        if get_render_mode() == "STL":
+            # read mesh from file
+            model = Mesh.read(str(model_path / (f"{name}.stl")))
+            
 
         # apply transformations from json
         info = json.load(open(model_path / (f"{name}.json")))
 
         rot = App.Rotation("XYZ", *info["rotation"])
         trans = App.Vector(*info["translation"])
+
         # Build matrices
         rot_mat = rot.toMatrix()
         trans_mat = App.Matrix()
@@ -641,10 +646,16 @@ def import_model(
         # Compose: translate first, then rotate
         final_mat = rot_mat.multiply(trans_mat)
         # Apply transform directly to mesh geometry
-        mesh.transform(final_mat)
+        if get_render_mode() == "STL":
+            model.transform(final_mat)
+        if get_render_mode() == "STEP":
+            if not np.all(np.isclose(final_mat.A, App.Placement().toMatrix().A)):
+                # transformGeometry is slow, so only call when there actually is something to transform
+                model = model.transformGeometry(final_mat)
+            model.Placement = App.Placement()
 
     except FileNotFoundError as e:
         print(f"Error importing model '{name}': {e}")
-        mesh = Mesh.Mesh()  # return empty mesh on error
+        model = None
 
-    return mesh
+    return model


### PR DESCRIPTION
New rendering modes STEP (for export) and None (for simulations/optimisation that doesn't require rendering).

The STEP mode is somewhat painfully slow (mainly due to shape.transformGeometry(), which is the only way I've found that consistently applies transformations to shapes (the shape.fuse(shape) trick fails for many imported STEP files). Still useful to export to other CAD software, but not to work in.

The None mode will be useful to avoid uneccesary recomputation of the geometry when optimising gaussian beam parameters etc.

Usage:
```
from PyOpticL import settings
settings.set_render_mode("STEP") 
# STEP files are loaded directly and not converted to meshes to allow for STEP export
# or
settings.set_render_mode("None") 
# No geometry is created
```