### PR TITLE
Conditions for intercepting a rectangular interface.

### DIFF
--- a/Designs/modules/example_baseplate.py
+++ b/Designs/modules/example_baseplate.py
@@ -6,6 +6,10 @@ from PyOpticL.utils import cardinal_angle, fix_relative_imports, turn_angle
 
 fix_relative_imports()
 
+# For the example baseplate in the quick start page on the wiki, 
+# instead of importing from modules.half_inch_library it needs to 
+# be from Designs.modules.half_inch_library.
+
 from half_inch_library import beamsplitter_cube, mirror, waveplate
 
 # define and place the baseplate object

--- a/PyOpticL/beam_path.py
+++ b/PyOpticL/beam_path.py
@@ -411,7 +411,7 @@ class BeamSegment(Layout):
             radius2 = self.get_beam_radius(q_param + dz)
             # create conical section
             # freecad does not support cones with equal radii
-            if isclose(radius1, radius2):
+            if isclose(radius1, radius2, abs_tol=1e-7):
                 shape = Part.makeCylinder(
                     radius1,
                     dz,

--- a/PyOpticL/settings.py
+++ b/PyOpticL/settings.py
@@ -1,6 +1,3 @@
-from PyOpticL import utils
-from importlib import reload
-
 measurement_system = "imperial"
 minimum_thread_engagement = 8
 default_extra_drill_depth = 10
@@ -19,7 +16,6 @@ def set_measurement_system(system: str):
     global measurement_system
     if system.lower() in ["metric", "imperial"]:
         measurement_system = system.lower()
-        reload(utils)
     else:
         raise ValueError("Invalid system preference. Use 'metric' or 'imperial'.")
 

--- a/PyOpticL/settings.py
+++ b/PyOpticL/settings.py
@@ -1,3 +1,6 @@
+from PyOpticL import utils
+from importlib import reload
+
 measurement_system = "imperial"
 minimum_thread_engagement = 8
 default_extra_drill_depth = 10
@@ -16,6 +19,7 @@ def set_measurement_system(system: str):
     global measurement_system
     if system.lower() in ["metric", "imperial"]:
         measurement_system = system.lower()
+        reload(utils)
     else:
         raise ValueError("Invalid system preference. Use 'metric' or 'imperial'.")
 


### PR DESCRIPTION
The check for an intercept being within the bounds of a rectangular interface is not defined right and doesn't account for the interface being rotated. Before rotation, the width of an interface is the distance along the y axis and its height is the distance along the z axis (I think they were taken to be x and y respectively before). To account for rotation, check that the component of the offset vector along the direction of the transverse vectors is less than half the appropriate dimension as the individual components of the offset vector don't tell you much about distances along a rotated plane.